### PR TITLE
Add tests for meta on resource objects.

### DIFF
--- a/test/adapter/json_api/resource_meta_test.rb
+++ b/test/adapter/json_api/resource_meta_test.rb
@@ -1,0 +1,63 @@
+require 'test_helper'
+
+module ActiveModel
+  class Serializer
+    module Adapter
+      class JsonApi
+        class ResourceMetaTest < Minitest::Test
+          class MetaHashPostSerializer < ActiveModel::Serializer
+            attributes :id
+            meta stuff: 'value'
+          end
+
+          class MetaBlockPostSerializer < ActiveModel::Serializer
+            attributes :id
+            meta do
+              { comments_count: object.comments.count }
+            end
+          end
+
+          def setup
+            @post = Post.new(id: 1337, comments: [], author: nil)
+          end
+
+          def test_meta_hash_object_resource
+            hash = ActiveModel::SerializableResource.new(
+              @post,
+              serializer: MetaHashPostSerializer,
+              adapter: :json_api
+            ).serializable_hash
+            expected = {
+              stuff: 'value'
+            }
+            assert_equal(expected, hash[:data][:meta])
+          end
+
+          def test_meta_block_object_resource
+            hash = ActiveModel::SerializableResource.new(
+              @post,
+              serializer: MetaBlockPostSerializer,
+              adapter: :json_api
+            ).serializable_hash
+            expected = {
+              comments_count: @post.comments.count
+            }
+            assert_equal(expected, hash[:data][:meta])
+          end
+
+          def test_meta_object_resource_in_array
+            hash = ActiveModel::SerializableResource.new(
+              [@post, @post],
+              each_serializer: MetaBlockPostSerializer,
+              adapter: :json_api
+            ).serializable_hash
+            expected = {
+              comments_count: @post.comments.count
+            }
+            assert_equal([expected, expected], hash[:data].map { |obj| obj[:meta] })
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/serializers/meta_test.rb
+++ b/test/serializers/meta_test.rb
@@ -3,6 +3,9 @@ require 'test_helper'
 module ActiveModel
   class Serializer
     class MetaTest < Minitest::Test
+
+      MetaBlogSerializer = Class.new(ActiveModel::Serializer)
+
       def setup
         @blog = Blog.new(id: 1,
                          name: 'AMS Hints',
@@ -124,6 +127,20 @@ module ActiveModel
           }
         }
         assert_equal(expected, actual)
+      end
+
+      def test_meta_is_set_with_direct_attributes
+        MetaBlogSerializer.meta stuff: 'value'
+        blog_meta_serializer = MetaBlogSerializer.new(@blog)
+        assert_equal(blog_meta_serializer.meta, { stuff: 'value' })
+      end
+
+      def test_meta_is_set_with_block
+        MetaBlogSerializer.meta do
+          { articles_count: object.articles.count }
+        end
+        blog_meta_serializer = MetaBlogSerializer.new(@blog)
+        assert_equal(blog_meta_serializer.meta, { articles_count: @blog.articles.count })
       end
     end
   end


### PR DESCRIPTION
@beauby what do you think about this as starting point? Are there any other tests that you think we should add? Do you think adding a new file is ok or is it a better place for these tests to live? 

TODO:
- [ ] Add serializer-level tests (testing `ActiveModel::Serializer.meta` and `ActiveModel::Serializer#meta`)
- [x] Adapt current test to make use of the `object` itself (in order to showcase the power of blocks over direct params)
- [x] Add test to make use of direct parameters
