### PR TITLE
Use return value of link block if any

### DIFF
--- a/lib/active_model/serializer/adapter/json_api.rb
+++ b/lib/active_model/serializer/adapter/json_api.rb
@@ -209,15 +209,7 @@ module ActiveModel
 
         def links_for(serializer)
           serializer.links.each_with_object({}) do |(name, value), hash|
-            hash[name] =
-              if value.respond_to?(:call)
-                link = Link.new(serializer)
-                link.instance_eval(&value)
-
-                link.to_hash
-              else
-                value
-              end
+            hash[name] = Link.new(serializer).value(value)
           end
         end
 

--- a/lib/active_model/serializer/adapter/json_api/link.rb
+++ b/lib/active_model/serializer/adapter/json_api/link.rb
@@ -10,29 +10,40 @@ module ActiveModel
 
           def href(value)
             self._href = value
+            nil
           end
 
           def meta(value)
             self._meta = value
+            nil
           end
 
-          def string(value)
-            self._string = value
-          end
-
-          def to_hash
-            return _string unless _string.nil?
-
-            hash = { href: _href }
-            hash.merge!(meta: _meta) if _meta
-
-            hash
+          def value(value)
+            if value.respond_to?(:call)
+              string instance_eval(&value)
+              _string || to_hash
+            else
+              value
+            end
           end
 
           protected
 
           attr_accessor :_href, :_meta, :_string
           attr_reader :object, :scope
+
+          private
+
+          def to_hash
+            hash = { href: _href }
+            hash.merge!(meta: _meta) if _meta
+
+            hash
+          end
+
+          def string(value)
+            self._string = value
+          end
         end
       end
     end

--- a/test/adapter/json_api/links_test.rb
+++ b/test/adapter/json_api/links_test.rb
@@ -15,7 +15,7 @@ module ActiveModel
             link :other, '//example.com/resource'
 
             link :yet_another do
-              string "//example.com/resource/#{object.id}"
+              "//example.com/resource/#{object.id}"
             end
           end
 


### PR DESCRIPTION
This commit leaves unresolved the behavior if there is both a return value to the block (as `_string`) and `meta` and/or `href` are set. To be decided in the receiving PR if merged.
