### PR TITLE
Use condition_type in case statement for included?

### DIFF
--- a/lib/active_model/serializer/field.rb
+++ b/lib/active_model/serializer/field.rb
@@ -38,7 +38,7 @@ module ActiveModel
       private
 
       def condition_type
-        @condition_type ||= begin
+        @condition_type ||=
           if options.key?(:if)
             :if
           elsif options.key?(:unless)
@@ -46,7 +46,6 @@ module ActiveModel
           else
             :none
           end
-        end
       end
 
       def condition

--- a/lib/active_model/serializer/field.rb
+++ b/lib/active_model/serializer/field.rb
@@ -25,7 +25,7 @@ module ActiveModel
       # @api private
       #
       def included?(serializer)
-        case condition
+        case condition_type
         when :if
           serializer.public_send(condition)
         when :unless
@@ -38,12 +38,14 @@ module ActiveModel
       private
 
       def condition_type
-        if options.key?(:if)
-          :if
-        elsif options.key?(:unless)
-          :unless
-        else
-          :none
+        @condition_type ||= begin
+          if options.key?(:if)
+            :if
+          elsif options.key?(:unless)
+            :unless
+          else
+            :none
+          end
         end
       end
 


### PR DESCRIPTION
condition is currently being used in the case statement, but that is
a reference to the method to call. Use the condition_type, which
says if it is an if or unless statement
